### PR TITLE
Add VimWiki to "Applications and Tools"

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@
 - [MindMeister](https://www.mindmeister.com/) - An online mind mapping tool that lets you capture, develop and share ideas visually.
 - [bundleIQ](https://www.bundleiq.com/) - An application to organize your thoughts and collaborate on shared ideas in an AI-powered workspace.
 - [Taskade](https://www.taskade.com/) - A task driven real-time collaborative outliner for organizing projects, notes, with integrated video chat.
+- [VimWiki](https://vimwiki.github.io/) - A flexible personal wiki in Vim, including diary features.
 
 ## Libraries
 


### PR DESCRIPTION
Adds a link to VimWiki.

I've been using this one extensively for ~4 years.

Repo here: https://github.com/vimwiki/vimwiki