### PR TITLE
Add MDLook

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@
 - [AFFiNE](https://affine.pro/) - Open source and privacy first next-generation collaborative knowledge base for professionals.
 - [Znote](https://znote.io) - A productivity-focused note-taking app designed for doers to create notes with actionable steps.
 - [samarbeid](https://www.samarbeid.org/) - An open source collaboration tool for non-technical teams that helps to manage all workflows, documents, data and chats in a networked space.
+- [MDLook](https://mdlook.com/) - A portable, fully offline Markdown editor for Windows using WebView2 instead of Electron.
 
 ## Semantic Web and RDF Ecosystem
 


### PR DESCRIPTION
Add MDLook to the tools section.

- Website: https://mdlook.com
- GitHub: https://github.com/djosci/MDLook

MDLook is a portable, fully offline Markdown editor for Windows. It uses WebView2 instead of Electron, keeping the total size at ~42 MB with no installation required. Features split-pane editing with live preview, dark mode, KaTeX math, Mermaid diagrams, and syntax highlighting.