### PR TITLE
Add IWE

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@
 - [exegesis](https://exegesis.io/) - A writing app for caputuring and sharing disorganized, non-linear, creative thinking.
 - [Apache TinkerPop](https://tinkerpop.apache.org/) - A graph computing framework for both graph databases (OLTP) and graph analytic systems (OLAP).
 - [Infinity Maps](https://infinitymaps.io/en/) - A knowledge management system to help you organize, structure and share your knowledge.
+- [IWE](https://iwe.md/) - A markdown-based knowledge management tool with graph navigation via LSP, working with VS Code, Neovim, Zed and Helix.
 - [Rekowl](https://rekowl.com/) - A personal knowledge management system to help you also get better at remembering.
 - [Kite](https://erkal.github.io/kite/) - A graph visualization and analysis tool.
 - [Outline](https://www.getoutline.com/) - A knowledge base for teams.


### PR DESCRIPTION
IWE is a markdown-based knowledge management tool that turns documents into a navigable graph. It provides an LSP server for editor integration (VS Code, Neovim, Zed, Helix) and a CLI for programmatic access.

Features: go-to-definition, backlinks, link completion, code actions (extract/inline), inclusion links for polyhierarchy.

Built in Rust, open source (Apache-2.0), 862+ GitHub stars.

GitHub: https://github.com/iwe-org/iwe