### PR TITLE
Add lifeos-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@
 - [RemNote](https://www.remnote.io/) - A spaced-repetition powered note-taking tool that lets you structure knowledge exactly in the way you think about it.
 - [Rember](https://www.rember.com/) - A simple yet powerful spaced repetition system designed to help you remember more. Rember uses AI to automatically generate cards and synchronizes across desktop and mobile.
 - [Hode](https://github.com/JeffreyBenjaminBrown/hode) An editor, search engine and query language for a knowledge hypergraph. Relationships can have any number of members, and those members can be other relationships.
+- [lifeos-cli](https://github.com/liujuanjuan1984/lifeos-cli) - A terminal-native LifeOS for structuring notes, tasks, habits, events, schedules, and timelogs in one CLI workflow.
 - [Joplin](https://joplinapp.org/) - An open source note taking and to-do application which can handle a large number of notes organized into notebooks. Markdown syntax, end-to-end encryption and syncing with several cloud services.
 - [Zim Wiki](https://zim-wiki.org) - A local, Python-based graphical wiki tool that uses the filesystem as a data store.
 - [Scrapbox](https://scrapbox.io/) - A knowledge base to create and research in context, including bi-directional linking and rapid outlining.


### PR DESCRIPTION
This adds `lifeos-cli` to `Platforms, Applications and Tools`.

Why it fits:
- it is a knowledge-oriented personal system rather than a single-purpose tracker
- it connects notes, tasks, habits, events, schedules, and timelogs in one terminal-native workflow
- it is especially relevant for people who want structured, local, command-line-first knowledge and life management
