### PR TITLE
Add Burn 451 to Platforms, Applications and Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@
 - [Znote](https://znote.io) - A productivity-focused note-taking app designed for doers to create notes with actionable steps.
 - [samarbeid](https://www.samarbeid.org/) - An open source collaboration tool for non-technical teams that helps to manage all workflows, documents, data and chats in a networked space.
 
+- [Burn 451](https://www.burn451.cloud) - An AI-powered reading tool that deletes what you never read and curates what you do. Editorial vaults for AI thought leaders (Karpathy, Simon Willison, Paul Graham, Naval Ravikant) plus hub concept pages on agentic engineering and vibe coding. [#opensource](https://github.com/Fisher521/killmybookmark)
+
 ## Semantic Web and RDF Ecosystem
 
 - [Apache Jena](https://jena.apache.org/) - Open-source Java framework for building RDF-based semantic web and linked data applications.


### PR DESCRIPTION
Adding [Burn 451](https://www.burn451.cloud) to the Platforms, Applications and Tools section.

Burn is an AI-powered reading tool with a KM twist: it deletes what you never read (breaking the 'infinite save' pattern) and organizes what you actually finish into public editorial vaults. Multi-source curation from high-signal thinkers:
- [Karpathy vault](https://www.burn451.cloud/vault/karpathy) — 37 pieces
- [Simon Willison vault](https://www.burn451.cloud/vault/simon-willison) — 19
- [Paul Graham vault](https://www.burn451.cloud/vault/paul-graham) — 30
- [Naval Ravikant vault](https://www.burn451.cloud/vault/naval-ravikant) — 22

Hub concept pages that cross-link the canonical essays:
- [Agentic Engineering](https://www.burn451.cloud/concepts/agentic-engineering)
- [Vibe Coding](https://www.burn451.cloud/concepts/vibe-coding)

Every piece has an AI summary. Open source: https://github.com/Fisher521/killmybookmark