### PR TITLE
Add pdfmarkdown.app to Platforms, Applications and Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@
 - [AFFiNE](https://affine.pro/) - Open source and privacy first next-generation collaborative knowledge base for professionals.
 - [Znote](https://znote.io) - A productivity-focused note-taking app designed for doers to create notes with actionable steps.
 - [samarbeid](https://www.samarbeid.org/) - An open source collaboration tool for non-technical teams that helps to manage all workflows, documents, data and chats in a networked space.
+- [pdfmarkdown.app](https://pdfmarkdown.app/) - A browser-based, no-upload PDF to Markdown converter that turns PDFs into clean, AI-ready Markdown with tables, formulas and images preserved; also Markdown to PDF.
 
 ## Semantic Web and RDF Ecosystem
 


### PR DESCRIPTION
Adds **pdfmarkdown.app** to *Platforms, Applications and Tools* (appended to the bottom of the category, per CONTRIBUTING).

pdfmarkdown.app is a browser-based PDF to Markdown converter — it turns PDFs into clean, AI-ready Markdown with tables, formulas and images preserved, and also does Markdown to PDF. Runs in your browser, no upload, no signup. Free.

Link: https://pdfmarkdown.app · Single entry, matched to the section format. I built and use it.
