### PR TITLE
Add NoteRich - AI-powered notes with RAG search

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@
 - [Hode](https://github.com/JeffreyBenjaminBrown/hode) An editor, search engine and query language for a knowledge hypergraph. Relationships can have any number of members, and those members can be other relationships.
 - [Joplin](https://joplinapp.org/) - An open source note taking and to-do application which can handle a large number of notes organized into notebooks. Markdown syntax, end-to-end encryption and syncing with several cloud services.
 - [Zim Wiki](https://zim-wiki.org) - A local, Python-based graphical wiki tool that uses the filesystem as a data store.
+- [NoteRich](https://noterich.com) - AI-powered notes with built-in RAG search. Import documents, ask natural language questions, find anything in seconds. 41 languages. Free tier. PRO: $39.90/year.
+
 - [Scrapbox](https://scrapbox.io/) - A knowledge base to create and research in context, including bi-directional linking and rapid outlining.
 - [MindMeister](https://www.mindmeister.com/) - An online mind mapping tool that lets you capture, develop and share ideas visually.
 - [bundleIQ](https://www.bundleiq.com/) - An application to organize your thoughts and collaborate on shared ideas in an AI-powered workspace.


### PR DESCRIPTION
Added NoteRich to Platforms, Applications and Tools section.

NoteRich is an AI-powered note-taking app with built-in RAG search. Import documents and search via natural language. 41 languages. Free tier, PRO $39.90/year.