### PR TITLE
Add tela to Platforms, Applications and Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@
 - [AFFiNE](https://affine.pro/) - Open source and privacy first next-generation collaborative knowledge base for professionals.
 - [Znote](https://znote.io) - A productivity-focused note-taking app designed for doers to create notes with actionable steps.
 - [samarbeid](https://www.samarbeid.org/) - An open source collaboration tool for non-technical teams that helps to manage all workflows, documents, data and chats in a networked space.
+- [tela](https://telawiki.com) - Open-source, self-hostable team wiki with a built-in MCP server so agents read and write it; Atlas turns a git repo or Jira into cited, maintained docs.
 
 ## Semantic Web and RDF Ecosystem
 


### PR DESCRIPTION
Adds **tela** to *Platforms, Applications and Tools* (bottom of the category, per CONTRIBUTING).

`- [tela](https://telawiki.com) - Open-source, self-hostable team wiki with a built-in MCP server so agents read and write it; Atlas turns a git repo or Jira into cited, maintained docs.`

Repository: https://github.com/zcag/tela (AGPL-3.0). Self-hostable team wiki / knowledge base with live collaboration, semantic + full-text search, and an Atlas engine that auto-generates cited documentation from a repo. Relevant alongside existing entries like Outline and AFFiNE.