### PR TITLE
Add Oats

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@
 - [AFFiNE](https://affine.pro/) - Open source and privacy first next-generation collaborative knowledge base for professionals.
 - [Znote](https://znote.io) - A productivity-focused note-taking app designed for doers to create notes with actionable steps.
 - [samarbeid](https://www.samarbeid.org/) - An open source collaboration tool for non-technical teams that helps to manage all workflows, documents, data and chats in a networked space.
+- [OATS](https://github.com/ariso-ai/oats) - Open-source macOS meeting-notes app that records conversations, transcribes them, labels speakers, and generates Markdown notes with an optional fully offline mode.
 
 ## Semantic Web and RDF Ecosystem
 


### PR DESCRIPTION
Adds Oats to the Platforms, Applications and Tools section.

Oats is an open-source macOS meeting-notes app that records conversations, transcribes them, labels speakers, and generates Markdown notes; it supports a fully offline mode, so it fits alongside the note-taking and personal knowledge-management tools already listed.
