### PR TITLE
Add MindBase (LLM-maintained personal wiki)

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@
 - [Joplin](https://joplinapp.org/) - An open source note taking and to-do application which can handle a large number of notes organized into notebooks. Markdown syntax, end-to-end encryption and syncing with several cloud services.
 - [Zim Wiki](https://zim-wiki.org) - A local, Python-based graphical wiki tool that uses the filesystem as a data store.
 - [Scrapbox](https://scrapbox.io/) - A knowledge base to create and research in context, including bi-directional linking and rapid outlining.
-- [MindBase](https://github.com/frankchu91/mindbase) - An open-source implementation of Karpathy's LLM Wiki idea: an AI maintains a persistent markdown wiki from your notes and sources — approval-gated updates, contradiction linting, runs on free local models.
+- [MindBase](https://github.com/frankchu91/mindbase-llm-wiki) - An open-source implementation of Karpathy's LLM Wiki idea: an AI maintains a persistent markdown wiki from your notes and sources — approval-gated updates, contradiction linting, runs on free local models.
 - [MindMeister](https://www.mindmeister.com/) - An online mind mapping tool that lets you capture, develop and share ideas visually.
 - [bundleIQ](https://www.bundleiq.com/) - An application to organize your thoughts and collaborate on shared ideas in an AI-powered workspace.
 - [Taskade](https://www.taskade.com/) - A task driven real-time collaborative outliner for organizing projects, notes, with integrated video chat.

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@
 - [Joplin](https://joplinapp.org/) - An open source note taking and to-do application which can handle a large number of notes organized into notebooks. Markdown syntax, end-to-end encryption and syncing with several cloud services.
 - [Zim Wiki](https://zim-wiki.org) - A local, Python-based graphical wiki tool that uses the filesystem as a data store.
 - [Scrapbox](https://scrapbox.io/) - A knowledge base to create and research in context, including bi-directional linking and rapid outlining.
+- [MindBase](https://github.com/frankchu91/mindbase) - An open-source implementation of Karpathy's LLM Wiki idea: an AI maintains a persistent markdown wiki from your notes and sources — approval-gated updates, contradiction linting, runs on free local models.
 - [MindMeister](https://www.mindmeister.com/) - An online mind mapping tool that lets you capture, develop and share ideas visually.
 - [bundleIQ](https://www.bundleiq.com/) - An application to organize your thoughts and collaborate on shared ideas in an AI-powered workspace.
 - [Taskade](https://www.taskade.com/) - A task driven real-time collaborative outliner for organizing projects, notes, with integrated video chat.


### PR DESCRIPTION
Adds [MindBase](https://github.com/frankchu91/mindbase) to Platforms, Applications and Tools (alphabetically, before MindMeister).

MindBase is an open-source (MIT) implementation of Andrej Karpathy's LLM Wiki idea: instead of retrieving from your notes at query time (RAG), an AI incrementally builds and maintains a markdown wiki from the sources you feed it. Updates are approval-gated (the model proposes a plan, the user approves), a lint operation surfaces contradictions between pages with quoted evidence, and it runs entirely locally on free models via Ollama — no API key. Everything is plain markdown on the user's disk.

Disclosure: I'm the author; PR prepared with an AI agent's help.