### PR TITLE
Add Verified Memory Vault to Platforms, Applications and Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@
 - [ThoughtDAG](https://github.com/chenxiachan/thoughtdag) - An open-source, local-first visual workspace for branching and managing LLM conversations, where graph edges determine the context sent to the model.
 - [Burn 451](https://www.burn451.cloud) - An AI-powered reading tool that deletes what you never read and curates what you do. Editorial vaults for AI thought leaders (Karpathy, Simon Willison, Paul Graham, Naval Ravikant) plus hub concept pages on agentic engineering and vibe coding.
 - [Persona](https://github.com/jayamitkatariya/personacli) - Local-first personal workspace: write notes, track tasks, chat with an AI that knows your files — all plain Markdown.
+- [Verified Memory Vault](https://github.com/secondbrainstarter/verified-memory-vault) - An open-source Obsidian-based agent memory system: plain Markdown memory files with a deterministic Python linter (`memory_check.py`) that scores hygiene, and a git pre-commit hook guarding against mass deletions by the agent itself.
 ## Semantic Web and RDF Ecosystem
 
 - [Apache Jena](https://jena.apache.org/) - Open-source Java framework for building RDF-based semantic web and linked data applications.


### PR DESCRIPTION
Adds [Verified Memory Vault](https://github.com/secondbrainstarter/verified-memory-vault) (open source, MIT/CC BY 4.0) to **Platforms, Applications and Tools**.

It is an agent memory system built on a plain Obsidian vault: memory lives in ordinary Markdown files that both humans and AI agents can read and edit. Two mechanisms address the failure modes specific to agent-maintained memories:

- `memory_check.py` — deterministic Python linter that scores memory hygiene (stale entries, broken links, duplicate facts); exit-code capable for CI or agent hooks.
- `memory_guard.py` — git pre-commit hook that blocks mass deletions of memory lines by the agent itself.

No runtime dependencies; works with any Markdown-based workflow.

Placed at the end of the section after Persona. Happy to adjust wording or move it if you prefer another spot.