### PR TITLE
Add Loofah to Platforms, Applications and Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@
 - [Burn 451](https://www.burn451.cloud) - An AI-powered reading tool that deletes what you never read and curates what you do. Editorial vaults for AI thought leaders (Karpathy, Simon Willison, Paul Graham, Naval Ravikant) plus hub concept pages on agentic engineering and vibe coding.
 - [Persona](https://github.com/jayamitkatariya/personacli) - Local-first personal workspace: write notes, track tasks, chat with an AI that knows your files — all plain Markdown.
 - [Verified Memory Vault](https://github.com/secondbrainstarter/verified-memory-vault) - An open-source Obsidian-based agent memory system: plain Markdown memory files with a deterministic Python linter (`memory_check.py`) that scores hygiene, and a git pre-commit hook guarding against mass deletions by the agent itself.
+- [Loofah](https://github.com/bart6114/loofah) - An MIT-licensed local-first workspace for meeting transcription and working knowledge stored as ordinary Markdown, with read-only MCP access for agents.
 ## Semantic Web and RDF Ecosystem
 
 - [Apache Jena](https://jena.apache.org/) - Open-source Java framework for building RDF-based semantic web and linked data applications.


### PR DESCRIPTION
Adds Loofah to Platforms, Applications and Tools.

I built Loofah for my own meeting notes and working knowledge, and I use it myself. It records and transcribes locally, stores notes as ordinary Markdown files, and gives agents read-only MCP access to the vault.

Affiliation: I'm the Loofah maintainer. This PR was prepared with an automated agent.
