### PR TITLE
Add igli.app to Platforms, Applications and Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,8 @@
 - [Burn 451](https://www.burn451.cloud) - An AI-powered reading tool that deletes what you never read and curates what you do. Editorial vaults for AI thought leaders (Karpathy, Simon Willison, Paul Graham, Naval Ravikant) plus hub concept pages on agentic engineering and vibe coding.
 - [Persona](https://github.com/jayamitkatariya/personacli) - Local-first personal workspace: write notes, track tasks, chat with an AI that knows your files — all plain Markdown.
 - [Verified Memory Vault](https://github.com/secondbrainstarter/verified-memory-vault) - An open-source Obsidian-based agent memory system: plain Markdown memory files with a deterministic Python linter (`memory_check.py`) that scores hygiene, and a git pre-commit hook guarding against mass deletions by the agent itself.
+- [igli.app](https://www.igli.app) - Convert Instagram carousels to PDFs (and back) to capture and archive posts in your knowledge base.
+  
 ## Semantic Web and RDF Ecosystem
 
 - [Apache Jena](https://jena.apache.org/) - Open-source Java framework for building RDF-based semantic web and linked data applications.


### PR DESCRIPTION
Adds igli.app — a free web tool that saves any public Instagram carousel as a single PDF so you can capture posts into a knowledge base (Notion, Obsidian, Readwise), and repurpose to LinkedIn. https://www.igli.app; Disclosure: I'm the maker (first‑hand use).