### PR TITLE
Add Lair to Platforms, Applications and Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@
 - [Burn 451](https://www.burn451.cloud) - An AI-powered reading tool that deletes what you never read and curates what you do. Editorial vaults for AI thought leaders (Karpathy, Simon Willison, Paul Graham, Naval Ravikant) plus hub concept pages on agentic engineering and vibe coding.
 - [Persona](https://github.com/jayamitkatariya/personacli) - Local-first personal workspace: write notes, track tasks, chat with an AI that knows your files — all plain Markdown.
 - [Verified Memory Vault](https://github.com/secondbrainstarter/verified-memory-vault) - An open-source Obsidian-based agent memory system: plain Markdown memory files with a deterministic Python linter (`memory_check.py`) that scores hygiene, and a git pre-commit hook guarding against mass deletions by the agent itself.
+- [Lair](https://lair.software/) - A native Mac library for collectors and writers: a database you own rather than a website you rent, with typed fields and a real writing space in every record.
 ## Semantic Web and RDF Ecosystem
 
 - [Apache Jena](https://jena.apache.org/) - Open-source Java framework for building RDF-based semantic web and linked data applications.


### PR DESCRIPTION
Adds **Lair** to the *Platforms, Applications and Tools* section.

Lair is a native Mac library for collectors and writers. It holds typed fields and a real writing space in the same record, so structured facts and longform prose live together rather than being split across a database and a notes app. Collections take the shape of the work they hold — a shelf, a watchlist, a project plan — and mentions keep the trails between documents, collections, and fields, browsable in both directions.

The library is a database on the user's own Mac: offline by default, no account, with optional iCloud sync through their own Apple Account. It is free for up to 420 active documents, with the Full Version a one-time purchase rather than a subscription.

**Checklist from `CONTRIBUTING.md`**

- First-hand experience: yes — I am the developer.
- Not already included: confirmed, no existing entry links `lair.software`.
- Relevant: this list covers Obsidian, Notion, Logseq, and Anytype; Lair is the same category.
- Format: `- [Name](link) - Description`.
- Placement: bottom of the category, per the guidelines.
- No trailing whitespace.

**Scope:** one line, one file. No other changes.

Repository: https://github.com/C947326/Lair.Software
